### PR TITLE
feat: add nitro-imessage-agent to works

### DIFF
--- a/content/1.works/nitro-imessage-agent.json
+++ b/content/1.works/nitro-imessage-agent.json
@@ -1,0 +1,9 @@
+{
+  "name": "Nitro iMessage Agent",
+  "category": "personal",
+  "description": "Durable iMessage AI agent template built with Nitro",
+  "url": "https://github.com/vercel-labs/nitro-imessage-agent-template",
+  "github": "https://github.com/vercel-labs/nitro-imessage-agent-template",
+  "date": "2026-05-04",
+  "tags": ["nitro", "ai", "vercel", "open-source"]
+}


### PR DESCRIPTION
Adds [nitro-imessage-agent-template](https://github.com/vercel-labs/nitro-imessage-agent-template) to the portfolio works list.

- Category: `personal` (not featured)
- Tags: nitro, ai, vercel, open-source