### PR TITLE
fix(content): pin DB type to sqlite — bypass NuxtHub auto-derive on Vercel

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,10 +155,6 @@ Respect draft writing and clipboard entries only when includeDrafts is true on c
   },
 
   content: {
-    database: {
-      type: 'sqlite',
-      filename: '/tmp/contents.sqlite',
-    },
     build: {
       markdown: {
         highlight: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,6 +155,12 @@ Respect draft writing and clipboard entries only when includeDrafts is true on c
   },
 
   content: {
+    // Pin the build-time DB to sqlite so the NuxtHub preset's auto-derive
+    // (driven by `hub.db`) doesn't leak an unrecognized `type` into
+    // `#content/adapter` on Vercel. Hub Postgres is still used by other
+    // modules (better-auth); Nuxt Content reads its prebundled SQLite
+    // from build assets at runtime regardless.
+    database: { type: 'sqlite' },
     build: {
       markdown: {
         highlight: {


### PR DESCRIPTION
## Summary

Replaces the previous `content.database.filename: '/tmp/contents.sqlite'` override (which pointed at ephemeral storage on Vercel and caused 500s on every `/__nuxt_content/<col>/query`) with an explicit `content.database: { type: 'sqlite' }`. Pinning the type bypasses `@nuxt/content`'s NuxtHub preset auto-derivation, which on Vercel was producing an unrecognized `type` and ultimately setting `config.alias['#content/adapter']` to `undefined`.

## Symptom

```
2026-05-10T12:03:38.121Z  [info] Nuxt Icon server bundle mode is set to `local`
2026-05-10T12:03:38.125Z  [error] Cannot read properties of undefined (reading 'endsWith')
                          at bundle (@nuxt/nitro-server@4.4.4/dist/index.mjs:675:38)
2026-05-10T12:03:38.303Z  ELIFECYCLE  Command failed with exit code 1.
2026-05-10T12:03:38.353Z  Error: Command "pnpm install" exited with 1
```

The crash hit during `pnpm install` postinstall (`nuxt prepare`), so the deploy died before the actual build. Side effects:

- The `Hugo Richard — Portfolio` MCP server (`assistant-context`, `content-list`, `content-get`) returned 500s on every call — assistants and agents grounding on the portfolio could not load `about`, projects, or posts.
- Public site rendering was affected for any path hitting a Nuxt Content runtime query.

## Root cause walk-through

1. With `hub: { db: 'postgresql' }` set, `@nuxt/content`'s `findPreset(nuxt)` returns the **NuxtHub preset** because `@nuxthub/core` is installed.
2. The NuxtHub preset's `setup()` runs in `modules:done` and tries to mirror Hub's database into `content.options.database`. On Vercel during prepare, `runtimeConfig.hub.db` doesn't expose the shape the preset expects, so `options.database` ends up with `{ type: <unrecognized> }`.
3. Later, in the `nitro:config` hook, `@nuxt/content` calls:

   ```ts
   config.alias['#content/adapter'] = await resolveDatabaseAdapter(
     config.runtimeConfig.content.database?.type || options.database.type,
     resolveOptions,
   )
   ```

   With an unrecognized type, `resolveDatabaseAdapter` falls through to `return databaseConnectors[adapter]` and returns `undefined`.
4. `@nuxt/nitro-server`'s `bundle()` then iterates `nitroConfig.alias` and calls `aliases[alias].endsWith('/')` — `undefined.endsWith` throws.

This issue did not exist before (last green deploy 4h prior was on a Renovate branch), so it's a recent transitive-dep regression in the NuxtHub-preset path.

## Fix

```diff
   content: {
-    database: {
-      type: 'sqlite',
-      filename: '/tmp/contents.sqlite',
-    },
+    // Pin the build-time DB to sqlite so the NuxtHub preset's
+    // auto-derive doesn't leak an unrecognized `type` into
+    // `#content/adapter` on Vercel. Hub Postgres is still used by
+    // other modules (better-auth); Nuxt Content reads its prebundled
+    // SQLite from build assets at runtime regardless.
+    database: { type: 'sqlite' },
     build: {
       markdown: { ... },
     },
   },
```

`findBestSqliteAdapter()` then resolves to a valid `db0/connectors/better-sqlite3` and the alias gets a real string. Hub Postgres is still wired and used by `@onmax/nuxt-better-auth` for app data — only the Nuxt Content build DB is pinned here.

## Test plan

- [x] Local `pnpm exec nuxt prepare` — runs cleanly, no 'endsWith' crash.
- [x] Local `pnpm run build` — Nuxt Content phase reports `Processed 7 collections and 40 files`, no error.
- [x] Vercel preview deploy on this branch is **Ready** (`hr-folio-ge6iu2nzo-hrcd.vercel.app`).
- [ ] Verify on the preview that `/__nuxt_content/about/query` returns JSON (gated by Vercel preview auth — needs `vercel curl` or merging to prod).
- [ ] Verify the portfolio MCP `assistant-context` returns the `about` block end-to-end after merge to main.
- [ ] Promote to production once the post-merge prod deploy is green.

## Follow-up

This shouldn't have regressed silently. Worth filing an issue against `@nuxt/content` so its NuxtHub preset either: (a) returns a recognized type for the `hub.db: 'postgresql'` (string-form) shape on Vercel, or (b) defaults `#content/adapter` to a safe connector when derivation fails instead of `undefined`.