### PR TITLE
fix(content): use native node:sqlite connector for Vercel runtime

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -161,6 +161,14 @@ Respect draft writing and clipboard entries only when includeDrafts is true on c
     // modules (better-auth); Nuxt Content reads its prebundled SQLite
     // from build assets at runtime regardless.
     database: { type: 'sqlite' },
+    // Use Node's built-in `node:sqlite` (Node 22+) at runtime instead of
+    // the default `better-sqlite3`. The native connector loads the
+    // prebundled DB in-memory at cold start and never tries to write to
+    // disk — `better-sqlite3` does, and Vercel Functions have a
+    // read-only `/var/task` so it crashes with
+    // `ENOENT: mkdir '/var/task/.data'` on every query. Same pattern
+    // Docus uses (layer/nuxt.config.ts).
+    experimental: { sqliteConnector: 'native' },
     build: {
       markdown: {
         highlight: {


### PR DESCRIPTION
## Summary

After #224 the build passes, but runtime queries against the Nuxt Content DB now die on every Vercel Function invocation with:

```
ENOENT: no such file or directory, mkdir '/var/task/.data'
  at mkdirSync (node:fs:1370:26)
  at getDB (.../nitro.mjs:18600:3)
```

`/var/task` is read-only on Vercel Lambda, and the default `better-sqlite3` connector tries to write a SQLite file there.

This patch sets:

```ts
content: {
  experimental: { sqliteConnector: 'native' },
  ...
}
```

That switches Nuxt Content to Node's built-in `node:sqlite` (stable since Node 22.5). The native connector loads the prebundled DB in-memory at cold start and never touches disk — which is exactly the model Vercel Functions need.

Same pattern Docus ships in [`layer/nuxt.config.ts`](https://github.com/nuxt-content/docus/blob/main/layer/nuxt.config.ts) — they hit the same wall and resolved it with the same flag.

## Symptom (post-#224)

MCP `assistant-context`, `content-list`, `content-get` all return 200 from the route handler, but the underlying `/__nuxt_content/<col>/query` calls 500 with `ENOENT mkdir '/var/task/.data'`. Effects:

- The portfolio MCP server is callable but answers nothing useful (every collection query 500s).
- Public pages that hit a Nuxt Content runtime query in production also break.

## Test plan

- [x] Local `pnpm exec nuxt prepare` clean.
- [ ] Vercel preview deploys successfully on this branch.
- [ ] `curl https://<preview>.vercel.app/__nuxt_content/about/query` returns JSON, not 500.
- [ ] Portfolio MCP `assistant-context` returns the `about` block end-to-end on the preview.
- [ ] Promote to prod once preview is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SQLite database connector configuration to use Node's built-in native connector for improved performance and compatibility with Node 22+ environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/hr-folio/pull/225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->