### PR TITLE
fix(content): use pglite (WASM in-memory) for Vercel runtime

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,20 +155,20 @@ Respect draft writing and clipboard entries only when includeDrafts is true on c
   },
 
   content: {
-    // Pin the build-time DB to sqlite so the NuxtHub preset's auto-derive
-    // (driven by `hub.db`) doesn't leak an unrecognized `type` into
-    // `#content/adapter` on Vercel. Hub Postgres is still used by other
-    // modules (better-auth); Nuxt Content reads its prebundled SQLite
-    // from build assets at runtime regardless.
-    database: { type: 'sqlite' },
-    // Use Node's built-in `node:sqlite` (Node 22+) at runtime instead of
-    // the default `better-sqlite3`. The native connector loads the
-    // prebundled DB in-memory at cold start and never tries to write to
-    // disk — `better-sqlite3` does, and Vercel Functions have a
-    // read-only `/var/task` so it crashes with
-    // `ENOENT: mkdir '/var/task/.data'` on every query. Same pattern
-    // Docus uses (layer/nuxt.config.ts).
-    experimental: { sqliteConnector: 'native' },
+    // PGlite (Postgres in WASM, in-memory) instead of SQLite to dodge
+    // both Vercel runtime traps:
+    //   - the NuxtHub preset's auto-derive (driven by `hub.db`) leaking
+    //     an unrecognized type into `#content/adapter` at build, and
+    //   - `better-sqlite3` (the default sqlite connector) trying to
+    //     `mkdir '/var/task/.data'` at runtime on Vercel Lambda where
+    //     `/var/task` is read-only.
+    //
+    // PGlite ships as `@electric-sql/pglite` (already a dep), runs
+    // entirely in WASM with no disk writes, and is supported by Nuxt
+    // Content's `db0/connectors/pglite` adapter. Hub Postgres remains
+    // wired for other modules (better-auth); only the Nuxt Content
+    // build/runtime DB is pinned here.
+    database: { type: 'pglite' },
     build: {
       markdown: {
         highlight: {


### PR DESCRIPTION
## Summary

After #225, queries still 500 in production with:

\`\`\`
ENOENT: no such file or directory, mkdir '/var/task/.data'
  at mkdirSync (node:fs:1370:26)
  at getDB (.../nitro.mjs:18603:3)
\`\`\`

The \`experimental.sqliteConnector: 'native'\` flag did not take effect because \`isNodeSqliteAvailable()\` runs at **build time**, not runtime. If Vercel's build container's Node doesn't expose \`process.getBuiltinModule('node:sqlite')\` (or hits the \`ExperimentalWarning\` short-circuit), Nuxt Content falls through to \`db0/connectors/better-sqlite3\`, which writes its DB under \`<cwd>/.data/...\` → \`/var/task/.data\` on Vercel Lambda. \`/var/task\` is read-only, so every query crashes.

## Fix

Switch the Nuxt Content build/runtime DB to **PGlite** (Postgres in WASM, in-memory):

\`\`\`diff
   content: {
-    database: { type: 'sqlite' },
-    experimental: { sqliteConnector: 'native' },
+    database: { type: 'pglite' },
     build: { ... },
   },
\`\`\`

- \`@electric-sql/pglite\` is already a dep (used transitively by \`@nuxthub/core\`'s \`hub.db\` driver).
- Nuxt Content's connector map includes \`pglite\` → \`db0/connectors/pglite\`.
- PGlite runs entirely in WASM, no disk writes, no Node version requirement, no \`/tmp\` workaround needed.

Hub Postgres stays wired for \`@onmax/nuxt-better-auth\` (separate concern). Only the Nuxt Content build/runtime DB is pinned here.

## Test plan

- [x] Local \`pnpm exec nuxt prepare\` clean.
- [x] Local \`pnpm run dev\` boots, \`/__nuxt_content/about/query\` reaches the request validation layer (\`Invalid query: Query cannot be empty\` on empty POST body) — DB is alive, just the request body needs a query field. No \`mkdir\`/\`ENOENT\`.
- [ ] Vercel preview deploys successfully on this branch.
- [ ] On preview, posting a real query body to \`/__nuxt_content/about/query\` returns JSON.
- [ ] Portfolio MCP \`assistant-context\` returns the \`about\` block end-to-end.
- [ ] Promote to prod once preview is green.

## Why this works where the prior attempts didn't

| Attempt | What it tried | Why it failed |
| --- | --- | --- |
| #224 (initial) | Drop the \`/tmp/contents.sqlite\` filename override | Surfaced the \`#content/adapter\` undefined crash at prepare |
| #224 (final) | Pin \`database.type: 'sqlite'\` | Got the build through, but runtime sqlite still wrote to \`/var/task/.data\` |
| #225 | Add \`experimental.sqliteConnector: 'native'\` | Native check runs at build time; if Vercel's build Node lacks \`node:sqlite\`, the resolver still picks \`better-sqlite3\` |
| **#226 (this)** | \`database.type: 'pglite'\` | WASM, in-memory, no Node version dep, no disk writes |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated content database configuration for improved performance and deployment compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/hr-folio/pull/226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->