### PR TITLE
fix(chat): use Nitro useStorage('cache') instead of Hub kv

### DIFF
--- a/server/utils/chat-rate-limit.ts
+++ b/server/utils/chat-rate-limit.ts
@@ -1,6 +1,11 @@
 import { createError, getRequestIP, type H3Event } from 'h3'
+import { useStorage } from 'nitropack/runtime'
 
 const KEY_PREFIX = 'folio:chat:daily'
+
+function rateStore() {
+  return useStorage('cache')
+}
 
 function utcDay(): string {
   return new Date().toISOString().slice(0, 10)
@@ -20,16 +25,16 @@ export function maxVisitorChatTurns(event: H3Event): number {
   return Math.min(500, Math.floor(n))
 }
 
-const TTL_SEC = 26 * 60 * 60
+const TTL_MS = 26 * 60 * 60 * 1000
 
 async function storageGetCount(key: string): Promise<number> {
-  return Number(await kv.get<number>(key) ?? 0)
+  return Number((await rateStore().getItem<number>(key)) ?? 0)
 }
 
 async function storageIncrCount(key: string): Promise<number> {
-  const cur = Number(await kv.get<number>(key) ?? 0)
+  const cur = Number((await rateStore().getItem<number>(key)) ?? 0)
   const next = cur + 1
-  await kv.set(key, next, { ttl: TTL_SEC })
+  await rateStore().setItem(key, next, { ttl: TTL_MS })
   return next
 }
 


### PR DESCRIPTION
## Summary

After #227 dropped `@nuxthub/core`, the visitor chat rate-limit code in `server/utils/chat-rate-limit.ts` still referenced the global `kv` (auto-imported by NuxtHub). Without Hub registered, `kv` is undefined at runtime, so every call to `/api/folio/access` and `/api/chat` 500s with:

```
ReferenceError: kv is not defined
  at storageGetCount (chunks/nitro/nitro.mjs:11522:29)
  at peekVisitorChatUsage (chunks/nitro/nitro.mjs:11535:22)
```

## Fix

Replace `kv.get(...)` / `kv.set(...)` with Nitro's built-in `useStorage('cache')` API. No Hub dependency, works on every Nitro preset.

```ts
import { useStorage } from 'nitropack/runtime'

function rateStore() {
  return useStorage('cache')
}

await rateStore().getItem<number>(key)
await rateStore().setItem(key, value, { ttl: TTL_MS })
```

## Trade-off

Nitro's default `cache` storage is in-memory per cold start on Vercel. For a per-day visitor rate limit on a personal portfolio this is fine — the limit is a soft cap, not a security boundary, and owners (`isFolioOwner`) bypass it entirely. If we ever want per-day caps that actually persist across cold starts, we can mount `cache` on Vercel Edge Config / KV via `nitro.storage` config.

## Test plan

- [x] `pnpm exec nuxt prepare` clean.
- [ ] Vercel preview deploys.
- [ ] `GET /api/folio/access` on the preview returns 200 with JSON instead of 500.
- [ ] Promote to prod once preview is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal storage layer for rate limiting functionality to improve performance and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/hr-folio/pull/228)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->