### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "db:migrate": "nuxt db migrate",
     "workflow:web": "npx workflow web"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.3",
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.112",
     "@ai-sdk/mcp": "^1.0.41",
@@ -69,16 +69,5 @@
     "automd": "^0.4.3",
     "eslint": "^9.39.4",
     "yaml": "^2.8.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "sharp"
-    ],
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "vue-demi"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,16 @@ allowBuilds:
   '@swc/core': false
   better-sqlite3: true
   sharp: true
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,12 @@ allowBuilds:
   '@swc/core': false
   better-sqlite3: true
   sharp: true
+  '@nestjs/core': false
+  '@prisma/client': true
+  '@prisma/engines': true
+  cbor-extract: false
+  prisma: true
+  puppeteer: false
 
 minimumReleaseAge: 2880
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false
+  vue-demi: false
+  '@swc/core': false
+  better-sqlite3: true
+  sharp: true


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Migrate `onlyBuiltDependencies` + `ignoredBuiltDependencies` from `package.json` → `allowBuilds` map in new `pnpm-workspace.yaml` (the `pnpm` field in `package.json` is no longer recognized in v11)

### 2. Add `minimumReleaseAge` to harden supply chain

2-day minimum age (2880 minutes) before any newly published dependency can resolve. Trusted-source allowlist exempts the Nuxt and Vercel ecosystems.

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (2216 entries pass supply-chain policies via `--lockfile-only`)
- [ ] CI passes: build.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded project package manager to a newer pnpm release.
  * Adjusted workspace build and release rules: refined which packages are allowed or excluded from builds and updated minimum release age and exclusion patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HugoRCD/hr-folio/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->